### PR TITLE
Only report supported hvac_modes and fan_modes

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -171,11 +171,13 @@ class LGDevice(climate.ClimateDevice):
 
     @property
     def hvac_modes(self):
-        return list(MODES.values()) + [c_const.HVAC_MODE_OFF]
+        import wideq
+        return [v for k, v in MODES.items() if wideq.ACMode[k].value in self._ac.model.value('SupportOpMode').options.values()] + [c_const.HVAC_MODE_OFF]
 
     @property
     def fan_modes(self):
-        return list(FAN_MODES.values())
+        import wideq
+        return [v for k, v in FAN_MODES.items() if wideq.ACFanSpeed[k].value in self._ac.model.value('SupportWindStrength').options.values()]
 
     @property
     def hvac_mode(self):


### PR DESCRIPTION
This updates climate.py to report the capabilities reported by the Smartthinq model information.

Our LP1419IVSM only supports `cool`, `fan_only` and `dry` `hvac_modes`, and the presence of `auto` would cause hass-smartthinq to set the temperature to the minimum whenever it's activated.

This updates it to filter the `hvac_modes` to only those which are listed in the device's SupportOpMode list, and to filter `fan_modes` to only those listed in the device's SupportWindStrength list.