### PR TITLE
Add support for measuring power draw from ACs

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -94,6 +94,7 @@ class LGDevice(climate.ClimateDevice):
         self._client = client
         self._device = device
         self._fahrenheit = fahrenheit
+        self._attrs = {'power':0}
 
         import wideq
         self._ac = wideq.ACDevice(client, device)
@@ -106,6 +107,10 @@ class LGDevice(climate.ClimateDevice):
         # store the timestamp for when we set this value.
         self._transient_temp = None
         self._transient_time = None
+
+    @property
+    def device_state_attributes(self):
+        return self._attrs
 
     @property
     def temperature_unit(self):
@@ -248,6 +253,7 @@ class LGDevice(climate.ClimateDevice):
 
             try:
                 state = self._ac.poll()
+                power = self._ac.get_power()
             except wideq.NotLoggedInError:
                 LOGGER.info('Session expired. Refreshing.')
                 self._client.refresh()
@@ -256,6 +262,9 @@ class LGDevice(climate.ClimateDevice):
             except wideq.NotConnectedError:
                 LOGGER.info('Device not available.')
                 return
+
+            if power:
+                self._attrs['power'] = power
 
             if state:
                 LOGGER.info('Status updated.')


### PR DESCRIPTION
Returns the power usage in Watts from the AC to home assistant as a device attribute.

Add these lines to configuration.yaml to get a graph of your AC's power usage: (note that history graph is deprecated according to HA but they don't give any clear instructions on what you're supposed to use instead, so the graph might stop working at some point in the future)

```
sensor:
    - platform: template
      sensors:
          ac_power_sensor:
              friendly_name: AC Power Usage
              value_template:
"{{states.climate.air_conditioner.attributes.power}}"
              unit_of_measurement: W

history_graph:
    power:
        name: Power Graph
        entities:
            - sensor.ac_power_sensor
```