### PR TITLE
Add support for ENERGY_SAVER

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -22,6 +22,7 @@ PLATFORM_SCHEMA = climate.PLATFORM_SCHEMA.extend({
 
 MODES = {
     'AI': c_const.HVAC_MODE_AUTO,
+    'ENERGY_SAVER': c_const.HVAC_MODE_AUTO,
     'HEAT': c_const.HVAC_MODE_HEAT,
     'COOL': c_const.HVAC_MODE_COOL,
     'FAN': c_const.HVAC_MODE_FAN_ONLY,


### PR DESCRIPTION
Without this, certain models get this error:

```
Traceback (most recent call last):
  File "[...]/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 286, in async_update_ha_state
    self._async_write_ha_state()
  File "[...]/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 320, in _async_write_ha_state
    state = self.state
  File "[...]/lib/python3.6/site-packages/homeassistant/components/climate/__init__.py", line 165, in state
    return self.hvac_mode
  File "[...]/config/custom_components/smartthinq/climate.py", line 188, in hvac_mode
    return MODES[mode.name]
KeyError: 'ENERGY_SAVER'

```

Arguably, `AUTO` is the wrong mapping here, but it seemed like the best fit to me (the model in question has "energy saver", "cool", "dry", and "fan" modes).