### PR TITLE
add swing modes

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -56,6 +56,7 @@ SWING_MODES = {
     'Up Right': [ACHSwingMode.ONE, ACVSwingMode.ONE] ,
     'Up': [ACHSwingMode.ALL, ACVSwingMode.ONE],
 }
+SWING_MODE_DEFAULT = "Unknown"
 
 
 MAX_RETRIES = 5
@@ -128,7 +129,7 @@ class LGDevice(ClimateEntity):
         self._transient_temp = None
         self._transient_time = None
         
-        self._swing_mode = 'UNKNOWN'
+        self._swing_mode = SWING_MODE_DEFAULT
 
     @property
     def device_state_attributes(self):
@@ -215,13 +216,13 @@ class LGDevice(ClimateEntity):
     @property
     def swing_mode(self):
         # try to find out if the (initial) state matches a known state actually
-        if self._swing_mode == "Unknown":
+        if self._swing_mode == SWING_MODE_DEFAULT:
             for k, v in SWING_MODES.items():
                 if v[0] == self._state.horz_swing and v[1] == self._state.vert_swing:
                     self._swing_mode = k
                     break
             else:
-                return "Unknown"
+                return SWING_MODE_DEFAULT
         
         return self._swing_mode
 

--- a/climate.py
+++ b/climate.py
@@ -9,7 +9,6 @@ from homeassistant.components.climate import const as c_const
 from custom_components.smartthinq import (
     CONF_LANGUAGE, KEY_DEPRECATED_COUNTRY,
     KEY_DEPRECATED_LANGUAGE, KEY_DEPRECATED_REFRESH_TOKEN)
-from wideq import ACHSwingMode, ACVSwingMode
 
 try:
     from homeassistant.components.climate import ClimateEntity
@@ -46,16 +45,17 @@ FAN_MODES = {
     'NATURE': 'nature',
     'POWER': 'power',
 }
-SWING_MODES = {
-    # name, [horz_key, vert_key]
-    'Off': [ACHSwingMode.OFF, ACVSwingMode.OFF],
-    'Vertical': [ACHSwingMode.OFF, ACVSwingMode.ALL] ,
-    'Horizontal': [ACHSwingMode.ALL, ACVSwingMode.OFF],
-    'Vertical and Horizontal': [ACHSwingMode.ALL, ACVSwingMode.ALL] ,
-    'Up Left': [ACHSwingMode.FIVE, ACVSwingMode.ONE] ,
-    'Up Right': [ACHSwingMode.ONE, ACVSwingMode.ONE] ,
-    'Up': [ACHSwingMode.ALL, ACVSwingMode.ONE],
-}
+
+def swing_modes_index():
+    from wideq import ACHSwingMode, ACVSwingMode
+            # name: [horz_key, vert_key]
+    return {'Off': [ACHSwingMode.OFF, ACVSwingMode.OFF],
+            'Vertical': [ACHSwingMode.OFF, ACVSwingMode.ALL] ,
+            'Horizontal': [ACHSwingMode.ALL, ACVSwingMode.OFF],
+            'Vertical and Horizontal': [ACHSwingMode.ALL, ACVSwingMode.ALL] ,
+            'Up Left': [ACHSwingMode.FIVE, ACVSwingMode.ONE] ,
+            'Up Right': [ACHSwingMode.ONE, ACVSwingMode.ONE] ,
+            'Up': [ACHSwingMode.ALL, ACVSwingMode.ONE]}
 SWING_MODE_DEFAULT = "Unknown"
 
 
@@ -217,7 +217,7 @@ class LGDevice(ClimateEntity):
     def swing_mode(self):
         # try to find out if the (initial) state matches a known state actually
         if self._swing_mode == SWING_MODE_DEFAULT:
-            for k, v in SWING_MODES.items():
+            for k, v in swing_modes_index().items():
                 if v[0] == self._state.horz_swing and v[1] == self._state.vert_swing:
                     self._swing_mode = k
                     break
@@ -230,8 +230,8 @@ class LGDevice(ClimateEntity):
         self._swing_mode = swing_mode
         LOGGER.info('Setting swing mode to %s...', self._swing_mode)
         
-        horiz_mode = SWING_MODES[self._swing_mode][0]
-        vert_mode = SWING_MODES[self._swing_mode][1]
+        horiz_mode = swing_modes_index()[self._swing_mode][0]
+        vert_mode = swing_modes_index()[self._swing_mode][1]
         
         LOGGER.info('Setting device horizontal swing mode to %s...', horiz_mode)
         self._ac.set_horz_swing(horiz_mode)
@@ -243,7 +243,7 @@ class LGDevice(ClimateEntity):
 
     @property
     def swing_modes(self):
-        return [k for k, v in SWING_MODES.items()]
+        return [k for k, v in swing_modes_index().items()]
 
     @property
     def hvac_mode(self):

--- a/climate.py
+++ b/climate.py
@@ -32,13 +32,11 @@ MODES = {
 }
 FAN_MODES = {
     'LOW': c_const.FAN_LOW,
-    'LOW_MID': 'low-mid',
     'MID': c_const.FAN_MEDIUM,
-    'MID_HIGH': 'mid-high',
     'HIGH': c_const.FAN_HIGH,
 
-    'NATURE': 'nature',
-    'POWER': 'power',
+    'NATURE': 'auto',
+    'POWER': 'jet',
 }
 SWING_MODES = {
     # id, [name, horz_key, vert_key]

--- a/climate.py
+++ b/climate.py
@@ -38,11 +38,13 @@ MODES = {
 }
 FAN_MODES = {
     'LOW': c_const.FAN_LOW,
+    'LOW_MID': 'low-mid',
     'MID': c_const.FAN_MEDIUM,
+    'MID_HIGH': 'mid-high',
     'HIGH': c_const.FAN_HIGH,
 
-    'NATURE': 'auto',
-    'POWER': 'jet',
+    'NATURE': 'nature',
+    'POWER': 'power',
 }
 SWING_MODES = {
     # id, [name, horz_key, vert_key]

--- a/climate.py
+++ b/climate.py
@@ -219,9 +219,9 @@ class LGDevice(ClimateEntity):
             for k, v in SWING_MODES.items():
                 if v[0] == self._state.horz_swing and v[1] == self._state.vert_swing:
                     self._swing_mode = k
-        
-        if self._swing_mode == "Unknown":
-            return "Unknown"
+                    break
+            else:
+                return "Unknown"
         
         return self._swing_mode
 

--- a/climate.py
+++ b/climate.py
@@ -47,14 +47,14 @@ FAN_MODES = {
     'POWER': 'power',
 }
 SWING_MODES = {
-    # id, [name, horz_key, vert_key]
-    'OFF': ['Off', ACHSwingMode.OFF, ACVSwingMode.OFF],
-    'VERT': ['Vertical', ACHSwingMode.OFF, ACVSwingMode.ALL] ,
-    'HORIZ': ['Horizontal', ACHSwingMode.ALL, ACVSwingMode.OFF],
-    'VERT_HORIZ': ['Vertical and Horizontal', ACHSwingMode.ALL, ACVSwingMode.ALL] ,
-    'UP_LEFT': ['Up Left', ACHSwingMode.FIVE, ACVSwingMode.ONE] ,
-    'UP_RIGHT': ['Up Right', ACHSwingMode.ONE, ACVSwingMode.ONE] ,
-    'UP': ['Up', ACHSwingMode.ALL, ACVSwingMode.ONE],
+    # name, [horz_key, vert_key]
+    'Off': [ACHSwingMode.OFF, ACVSwingMode.OFF],
+    'Vertical': [ACHSwingMode.OFF, ACVSwingMode.ALL] ,
+    'Horizontal': [ACHSwingMode.ALL, ACVSwingMode.OFF],
+    'Vertical and Horizontal': [ACHSwingMode.ALL, ACVSwingMode.ALL] ,
+    'Up Left': [ACHSwingMode.FIVE, ACVSwingMode.ONE] ,
+    'Up Right': [ACHSwingMode.ONE, ACVSwingMode.ONE] ,
+    'Up': [ACHSwingMode.ALL, ACVSwingMode.ONE],
 }
 
 
@@ -215,22 +215,22 @@ class LGDevice(ClimateEntity):
     @property
     def swing_mode(self):
         # try to find out if the (initial) state matches a known state actually
-        if self._swing_mode == "UNKNOWN":
+        if self._swing_mode == "Unknown":
             for k, v in SWING_MODES.items():
-                if v[1] == self._state.horz_swing and v[2] == self._state.vert_swing:
+                if v[0] == self._state.horz_swing and v[1] == self._state.vert_swing:
                     self._swing_mode = k
         
-        if self._swing_mode == "UNKNOWN":
+        if self._swing_mode == "Unknown":
             return "Unknown"
         
-        return SWING_MODES[self._swing_mode][0]
+        return self._swing_mode
 
     def set_swing_mode(self, swing_mode):
         self._swing_mode = swing_mode
         LOGGER.info('Setting swing mode to %s...', self._swing_mode)
         
-        horiz_mode = SWING_MODES[self._swing_mode][1]
-        vert_mode = SWING_MODES[self._swing_mode][2]
+        horiz_mode = SWING_MODES[self._swing_mode][0]
+        vert_mode = SWING_MODES[self._swing_mode][1]
         
         LOGGER.info('Setting device horizontal swing mode to %s...', horiz_mode)
         self._ac.set_horz_swing(horiz_mode)
@@ -242,7 +242,7 @@ class LGDevice(ClimateEntity):
 
     @property
     def swing_modes(self):
-        return [v[0] for k, v in SWING_MODES.items()]
+        return [k for k, v in SWING_MODES.items()]
 
     @property
     def hvac_mode(self):


### PR DESCRIPTION
As commented in #34 Home Assistant doesn't support two separate types of swing modes, like some LG ACs. I added a predefined list of combined modes which I found useful in my setup and exposed the functions to HA. Maybe you want to add it in some form to your project.