### PR TITLE
[WIP] use v2 names, use state file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,14 @@ You can also install it manually:
        $ python3 example.py -c US -l en-US
 
    For the `-c` and `-l` parameters, use your country and language code: SmartThinQ accounts are associated with a specific locale, so be sure to use the country you originally created your account with.
-   The script will ask you to open a browser, log in, and then paste the URL you're redirected to. It will then write a JSON file called `wideq_state.json`.
-
-   Look inside this file for a key called `"refresh_token"` and copy the value.
+   The script will ask you to open a browser, log in, and then paste the URL you're redirected to. It will then write a JSON file called `wideq_state.json`. Place the file in a directory accessible to Home Assistant.
 
 3. Add a stanza to your Home Assistant `configuration.yaml` like this:
 
        smartthinq:
-           token: [YOUR_TOKEN_HERE]
-           region: US
-           language: en-US
+           wideq_state: /config/wideq_state.json
 
-   Use your refresh token and country & language codes. If region and language are not provided, then 'US' and 'en-US' are default.
-   Start up Home Assistant and hope for the best.
+Where `/config/wideq_state.json` is the path to the JSON file you copied.
 
 Dishwasher Visualization Example
 --------------------------------

--- a/__init__.py
+++ b/__init__.py
@@ -60,7 +60,6 @@ def setup(hass, config):
         LOGGER.warning(DEPRECATION_WARNING)
         return True
 
-    LOGGER.error("Starting up")
 
     if KEY_SMARTTHINQ_DEVICES not in hass.data:
         hass.data[KEY_SMARTTHINQ_DEVICES] = []

--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,8 @@
 Support for LG Smartthinq devices.
 """
 import logging
+import os
+import json
 import wideq
 
 import voluptuous as vol
@@ -14,11 +16,10 @@ from homeassistant.helpers.entity import Entity
 DOMAIN = 'smartthinq'
 
 CONF_LANGUAGE = 'language'
+CONF_WIDEQ_STATE='wideq_state'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_TOKEN): cv.string,
-        CONF_REGION: cv.string,
-        CONF_LANGUAGE: cv.string,
+        vol.Required(CONF_WIDEQ_STATE): cv.string
         })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -59,25 +60,37 @@ def setup(hass, config):
         LOGGER.warning(DEPRECATION_WARNING)
         return True
 
+    LOGGER.error("Starting up")
+
     if KEY_SMARTTHINQ_DEVICES not in hass.data:
         hass.data[KEY_SMARTTHINQ_DEVICES] = []
 
-    refresh_token = config[DOMAIN].get(CONF_TOKEN)
-    region = config[DOMAIN].get(CONF_REGION)
-    language = config[DOMAIN].get(CONF_LANGUAGE)
+    state_file = config[DOMAIN].get(CONF_WIDEQ_STATE)
 
-    client = wideq.Client.from_token(refresh_token, region, language)
+    # Load the configuration from the state file
+    try:
+        with open(state_file) as f:
+            LOGGER.debug("State file found '%s'", os.path.abspath(state_file))
+            state = json.load(f)
+    except IOError:
+        state = {}
+        LOGGER.debug("No state file found (tried: '%s')",
+                     os.path.abspath(state_file))
 
-    hass.data[CONF_TOKEN] = refresh_token
-    hass.data[CONF_REGION] = region
-    hass.data[CONF_LANGUAGE] = language
+    client = wideq.Client.load(state)
+    hass.data[CONF_WIDEQ_STATE] = state
 
-    for device in client.devices:
-        hass.data[KEY_SMARTTHINQ_DEVICES].append(device.id)
+    while True:
+        try:
+            for device in client.devices:
+                hass.data[KEY_SMARTTHINQ_DEVICES].append(device.id)
 
-    for component in SMARTTHINQ_COMPONENTS:
-        discovery.load_platform(hass, component, DOMAIN, {}, config)
-    return True
+            for component in SMARTTHINQ_COMPONENTS:
+                discovery.load_platform(hass, component, DOMAIN, {}, config)
+            return True
+        except wideq.NotLoggedInError:
+            LOGGER.info('Session expired.')
+            client.refresh()
 
 
 class LGDevice(Entity):

--- a/climate.py
+++ b/climate.py
@@ -8,7 +8,8 @@ import time
 from homeassistant.components.climate import const as c_const
 from custom_components.smartthinq import (
     CONF_LANGUAGE, KEY_DEPRECATED_COUNTRY,
-    KEY_DEPRECATED_LANGUAGE, KEY_DEPRECATED_REFRESH_TOKEN)
+    KEY_DEPRECATED_LANGUAGE, KEY_DEPRECATED_REFRESH_TOKEN,
+    CONF_WIDEQ_STATE)
 
 try:
     from homeassistant.components.climate import ClimateEntity
@@ -70,16 +71,9 @@ TEMP_MAX_C = 30
 def setup_platform(hass, config, add_devices, discovery_info=None):
     import wideq
 
-    refresh_token = config.get(KEY_DEPRECATED_REFRESH_TOKEN) or \
-        hass.data.get(CONF_TOKEN)
-    country = config.get(KEY_DEPRECATED_COUNTRY) or \
-        hass.data.get(CONF_REGION)
-    language = config.get(KEY_DEPRECATED_LANGUAGE) or \
-        hass.data.get(CONF_LANGUAGE)
-
+    client = wideq.Client.load(hass.data[CONF_WIDEQ_STATE])
+    client.refresh()
     fahrenheit = hass.config.units.temperature_unit != '°C'
-
-    client = wideq.Client.from_token(refresh_token, country, language)
     add_devices(_ac_devices(hass, client, fahrenheit), True)
 
 
@@ -203,7 +197,7 @@ class LGDevice(ClimateEntity):
         import wideq
         return [v for k, v in MODES.items()
                 if wideq.ACMode[k].value in
-                self._ac.model.value('SupportOpMode').options.values()] \
+                self._ac.model.value('airState.opMode').options.values()] \
             + [c_const.HVAC_MODE_OFF]
 
     @property
@@ -211,7 +205,7 @@ class LGDevice(ClimateEntity):
         import wideq
         return [v for k, v in FAN_MODES.items()
                 if wideq.ACFanSpeed[k].value in
-                self._ac.model.value('SupportWindStrength').options.values()]
+                self._ac.model.value('airState.windStrength').options.values()]
 
     @property
     def swing_mode(self):

--- a/sensor.py
+++ b/sensor.py
@@ -32,7 +32,7 @@ LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the LG dishwasher entities"""
-
+""" 
     refresh_token = hass.data[CONF_TOKEN]
     region = hass.data[CONF_REGION]
     language = hass.data[CONF_LANGUAGE]
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if dishwashers:
         add_entities(dishwashers, True)
-    return True
+    return True """
 
 
 class LGDishWasherDevice(LGDevice):


### PR DESCRIPTION
This PR includes the set of changes necessary to use with with my wideq branch, opened as sampsyo/wideq#132

In particular, the following changes need to be addressed:

- Support for loading the user number and OAuth root url, which are both necessary in the v2 API.

This is resolved by using the json state file instead of manually transferring just the token to the Home Assistant `configuration.yaml` file. In theory, we could support both manually inserting the entries, but referring to the JSON file seems to be more robust and user friendly.

- Changing the name of hard coded values in climate.py to refer to their v2 api (`airState`) equivalents. 

Instead of using these values, the wideq api should provide an api independent method to get the supported operation modes and wind directions

this is marked as a wip because dishwasher support is currently disabled. Hopefully, I can get that working next.

If you would like v2 support, you can try using this branch, and installing the wideq branch here: https://github.com/no2chem/wideq using `pip install .` in your home-assistant environment.

addresses #87