### PR TITLE
fix load errors on HA 2025.4.1

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -10,6 +10,8 @@ from custom_components.smartthinq import (
     CONF_LANGUAGE, KEY_DEPRECATED_COUNTRY,
     KEY_DEPRECATED_LANGUAGE, KEY_DEPRECATED_REFRESH_TOKEN)
 
+from homeassistant.components.climate.const import HVACMode
+
 try:
     from homeassistant.components.climate import ClimateEntity
 except ImportError:
@@ -27,13 +29,13 @@ PLATFORM_SCHEMA = climate.PLATFORM_SCHEMA.extend({
 })
 
 MODES = {
-    'AI': c_const.HVAC_MODE_AUTO,
-    'ENERGY_SAVER': c_const.HVAC_MODE_AUTO,
-    'HEAT': c_const.HVAC_MODE_HEAT,
-    'COOL': c_const.HVAC_MODE_COOL,
-    'FAN': c_const.HVAC_MODE_FAN_ONLY,
-    'DRY': c_const.HVAC_MODE_DRY,
-    'ACO': c_const.HVAC_MODE_HEAT_COOL,
+    'AI': HVACMode.AUTO,
+    'ENERGY_SAVER': HVACMode.AUTO,
+    'HEAT': HVACMode.HEAT,
+    'COOL': HVACMode.COOL,
+    'FAN': HVACMode.FAN_ONLY,
+    'DRY': HVACMode.DRY,
+    'ACO': HVACMode.HEAT_COOL,
 }
 FAN_MODES = {
     'LOW': c_const.FAN_LOW,

--- a/sensor.py
+++ b/sensor.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from custom_components.smartthinq import (
     CONF_LANGUAGE, KEY_SMARTTHINQ_DEVICES, LGDevice)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_REGION, CONF_TOKEN, TIME_HOURS, PERCENTAGE
+from homeassistant.const import CONF_REGION, CONF_TOKEN, UnitOfTime, PERCENTAGE
 from homeassistant.helpers.entity import Entity
 
 import wideq
@@ -242,7 +242,7 @@ class LGACFilter(Entity):
 
     @property
     def unit_of_measurement(self):
-        return TIME_HOURS
+        return UnitOfTime.HOURS
 
     def update(self):
         """Poll for updated device status.


### PR DESCRIPTION
This add-on will not load on hass 2025.4.1. I examined the logs and found that a bunch of constants are no longer available. This fix enables extension to load without causing exceptions. I am unsure how to test further, but at least the exceptions were corrected
